### PR TITLE
Add in a site structure document to detail the expected site structure.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,11 @@
 
   <packaging>pom</packaging>
 
-  <name>HLUG Website</name>
+  <name>HLUG Website Project</name>
   <url>http://houstonlinux.org</url>
   <description>
-    The public facing website of the Houston Linux User's Group.
+    This project builds the staticly served portion of the Houston Linux User's Group
+    website.  This website can be found at http://houstonlinux.org/
   </description>
 
   <properties>
@@ -36,7 +37,44 @@
         <version>2.12</version>
       </extension>
     </extensions>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <version>3.6</version>
+        <dependencies>
+          <dependency>
+            <groupId>io.wcm.maven.skins</groupId>
+            <artifactId>reflow-velocity-tools</artifactId>
+            <version>1.0.0</version>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.velocity</groupId>
+            <artifactId>velocity</artifactId>
+            <version>1.7</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
   </build>
+
+  <reporting>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-project-info-reports-plugin</artifactId>
+        <version>2.9</version>
+        <reportSets>
+          <reportSet>
+            <reports>
+              <report>index</report>
+              <report>project-team</report>
+            </reports>
+          </reportSet>
+        </reportSets>
+      </plugin>
+    </plugins>
+  </reporting>
 
   <profiles>
     <profile>
@@ -47,25 +85,10 @@
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-site-plugin</artifactId>
             <version>3.6</version>
-            <dependencies>
-              <dependency>
-                <groupId>io.wcm.maven.skins</groupId>
-                <artifactId>reflow-velocity-tools</artifactId>
-                <version>1.0.0</version>
-              </dependency>
-              <dependency>
-                <groupId>org.apache.velocity</groupId>
-                <artifactId>velocity</artifactId>
-                <version>1.7</version>
-              </dependency>
-            </dependencies>
             <configuration>
               <siteDirectory>${basedir}/src/website/</siteDirectory>
               <outputDirectory>${project.build.directory}/website/</outputDirectory>
               <stagingDirectory>${project.build.directory}/website-stage/</stagingDirectory>
-<!--
-              <templateFile>${basedir}/src/website/site.vm</templateFile>
--->
             </configuration>
           </plugin>
         </plugins>
@@ -75,7 +98,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-project-info-reports-plugin</artifactId>
-            <version>2.8</version>
+            <version>2.9</version>
             <configuration>
               <skip>true</skip>
             </configuration>

--- a/src/site/markdown/structure.md
+++ b/src/site/markdown/structure.md
@@ -1,0 +1,68 @@
+# Website Navigational Structure
+
+The Houston Linux User's Group Website has a navigational structure to facilitate the ease
+of finding, adding, and updating web pages within the site.  This structure permits one to
+locate a page based on a site hierarchy.  The intent is for a person who is looking for a
+bit of information to be able to narrow their search through the website, by identifying
+the categories the information might be within, and finding the information within those
+categories.
+
+## Goals
+
+1. Provide a better user experience by presenting and establishing a communicated structure
+   by which users can find the information of interest where they would expect it.
+2. Provide the user with site links which lead to pages that aggregate the offered
+   categories of presented information.
+3. Provide the indexing bots with a regular URL pattern that corresponds with the categories
+   we wish the bot to index.
+
+# Approach
+
+To this end, we employ a tree based site structure, with permissible cross-linking between
+the pages under the tree.  
+
+The primary tree-based structure is directly reflected in the
+filesystem layout of the deployed web pages and the primary navigational links.  It may be
+presented in a hierarchical breadcrumb trail, and is the canonical "location" of a page within
+the website.
+
+The permissible cross-linking consists of hypertext anchors contained within content that
+might link to pages outside of the subtree of the current page.  Cross-linking will never be
+presented as a primary means of navigating the web site hierarchy, and will not be permitted
+within the menu structure, nor reflected within a site breadcrumb location.
+
+The website structure is represented with a pattern.  The root node of the tree follows
+normal conventions of being alternatively presented as `/` or `/index.html`.  URL locations
+will always end with a consistent suffix, for URLs presented to the user as the current
+location.  Currently the suffix for the website is `.html`.
+
+# Hierarchy Structure
+
+The hierarchy is structured as follows:
+
+* / (/index.html)
+  * /category1.html
+    * /category1/item1.html
+    * /category1/item2.html
+  * /category2.html
+    * /category2/item1.html
+    * /category2/item2.html
+
+where the currently supported categories are
+
+* meetings (this contains a list of upcoming meetings)
+* locations (this contains a list of the locations)
+* calendar (an alternative presentation of meetings, with no sub items)
+* education (a list of the educational offerings)
+* socialization (a list of the socialization opportunities)
+* advocacy (a list of items and activities we support)
+* support (a list of support efforts, item pages detailing offerings and expectations)
+
+Exact duplication of pages within different categories is not permissible; however, two
+pages describing the same event or activity are supported and encouraged.  In the event of
+multiple pages detailing the same event or activity, both pages should be written to address
+the concern as if it were navigated to by the parent page, and then detail that more
+information in a hypertext link resembling "more information about the (concern) of this
+event here".  The exact wording of the link is not fixed, but it must contain a reference
+to the category of information, and a hint that you are switching categories.
+

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project name="HLUG Website Project"
+  xmlns="http://maven.apache.org/DECORATION/1.3.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/DECORATION/1.3.0 http://maven.apache.org/xsd/decoration-1.3.0.xsd">
+
+  <skin>
+    <groupId>lt.velykis.maven.skins</groupId>
+    <artifactId>reflow-maven-skin</artifactId>
+    <version>1.1.1</version>
+  </skin>
+
+  <custom>
+    <reflowSkin>
+      <smoothScroll>true</smoothScroll>
+      <theme>bootswatch-spacelab</theme>
+    </reflowSkin>
+  </custom>
+
+  <body>
+    <menu ref="reports"/>
+  </body>
+
+</project>


### PR DESCRIPTION
This document is meant to be a starting guideline for the layout of
the website's navigational structure and details which relate to the
website navigational structure.

This document, structure.md, should assist in documenting the standards
for additional sumbissions, and in the standards for the review of such
submissions; however, it is not an absolute document.  Rather, it is a
starting point for the current practices.

Issue-7