### PR TITLE
Add Support web page

### DIFF
--- a/src/website/markdown/index.md
+++ b/src/website/markdown/index.md
@@ -24,7 +24,7 @@ Looking to mingle with Linux loving people?
 
 [hlug-advocacy]: advocacy/
 [hlug-education]: education/
-[hlug-support]: support/
+[hlug-support]: support.html
 [hlug-socializing]: social/
 
 ---

--- a/src/website/markdown/support.md
+++ b/src/website/markdown/support.md
@@ -1,7 +1,7 @@
 # Support Offerings
 
 The Houston Linux User's Group can help you install your Linux system, configure
-it to your liking, and use the applicaitons within to achieve your goals.  Our
+it to your liking, and use the applications within to achieve your goals.  Our
 volunteers hold Lab Sessions where you can bring your hardware for one-on-one 
 assistance.  Most issues can be resolved within a single meeting.  Tasks
 requiring large amounts of effort are welcome, but may stretch across multiple
@@ -35,13 +35,12 @@ most common configuration requests.
 
 ## Application Support
 
-The typical Linux installation comes with a large number of free, freely
-available software packages.  The breadth and depth of freely available software
-is staggering.  For nearly every software solution, there is a Linux port or
-analogue.
+The typical Linux installation comes with a large number of free software
+packages.  The breadth and depth of freely available software is staggering.
+For nearly every software solution, there is a Linux port or analogue.
 
 The Houston Linux User's Group has experience with the most commonly used Linux
-software packages.  While we cannot accomodate support for every application,
-our volunteers have experience with the majority of popular applications.  If
-looking for a solution to a specific problem, our volunteers might suggest
-applications to suit your needs.
+software packages.  While we cannot accommodate support requests for every
+application, we are happy to help with familiar, popular applications.  If
+you are looking for a solution to a specific problem, our volunteers might
+suggest applications to suit your needs.

--- a/src/website/markdown/support.md
+++ b/src/website/markdown/support.md
@@ -1,0 +1,47 @@
+# Support Offerings
+
+The Houston Linux User's Group can help you install your Linux system, configure
+it to your liking, and use the applicaitons within to achieve your goals.  Our
+volunteers hold Lab Sessions where you can bring your hardware for one-on-one 
+assistance.  Most issues can be resolved within a single meeting.  Tasks
+requiring large amounts of effort are welcome, but may stretch across multiple
+Lab Sessions.
+
+## Installation Support
+
+While most major Linux distributions now install without a hiccup, there are
+times when installations can be a challenge.  Support is available for all
+skill levels.  New Linux users can get first-distro recommendations, and 
+volunteer-guided installations of their chosen distro.  Seasoned Linux veterans
+can get best-effort assistance with non-typical hardware issues, dbus tweaking,
+firmware, and more.  The volunteers of the Houston Linux User's Group are happy
+to assist the installation process along when things go wrong.
+
+The Houston Linux User's Group is glad to assist with installations; but,
+obscure distros and very old hardware might present challenges that exceed the
+resources of our volunteer staff.  While many volunteers are happy to work with
+off-the-beaten path hardware or distros, not all combinations are feasible.  
+
+## Configuration Support
+
+There are a multitude of ways to tweak a Linux system to your liking.  Desktop
+environments, display managers, graphics drivers, system fonts, backgrounds,
+boot screens, system services, and custom application launchers are just a few
+of the many ways one can alter their Linux system to their liking.  
+
+The Houston Linux User's Group is happy to assist in the configuration of your
+Linux installation to achieve your goals.  Our volunteers have experience with
+most common configuration requests.  
+
+## Application Support
+
+The typical Linux installation comes with a large number of free, freely
+available software packages.  The breadth and depth of freely available software
+is staggering.  For nearly every software solution, there is a Linux port or
+analogue.
+
+The Houston Linux User's Group has experience with the most commonly used Linux
+software packages.  While we cannot accomodate support for every application,
+our volunteers have experience with the majority of popular applications.  If
+looking for a solution to a specific problem, our volunteers might suggest
+applications to suit your needs.

--- a/src/website/site.xml
+++ b/src/website/site.xml
@@ -47,6 +47,7 @@
     <links>
 <!-- Who what when where why -->
       <item name="Welcome" href="index.html"/>
+      <item name="Support" href="support.html"/>
       <item name="Events" href="events.html"/>
 <!-- Meetings -->
     </links>


### PR DESCRIPTION
This web page will be raised when someone clicks on the support
menu entry or the support carousel banner.

Fixes #18